### PR TITLE
Remove string manipulation on Date variables

### DIFF
--- a/carrot_rcc.ts
+++ b/carrot_rcc.ts
@@ -250,33 +250,6 @@ const inferType = async (
   return "Json";
 };
 
-const TZ: string = ((): string => {
-  const date = new Date();
-  const offset = date.getTimezoneOffset();
-  const base = Math.floor(offset / 60) * -100 + (offset % 60);
-  if (offset == 0) {
-    return "+0000";
-  } else if (base >= 1000) {
-    return `+${base}`;
-  } else if (base >= 100) {
-    return `+0${base}`;
-  } else if (base >= 10) {
-    return `+00${base}`;
-  } else if (base >= 1) {
-    return `+000${base}`;
-  } else if (base <= -1000) {
-    return `-${base}`;
-  } else if (base <= -100) {
-    return `-0${base}`;
-  } else if (base <= -10) {
-    return `-00${base}`;
-  } else if (base <= -1) {
-    return `-000${base}`;
-  } else {
-    return "+0000";
-  }
-})();
-
 interface File {
   name: string;
   hex: string;
@@ -529,9 +502,7 @@ const save = async (
           patch.modifications[name] = {
             value: (typeof current[name].getMonth === "function"
               ? current[name].toISOString()
-              : `${current[name].substring(0, 10)}T${current[name].substring(
-                  11
-                )}${TZ}`
+              : current[name]
             ).replace(/Z$/, "+0000"),
             type: "Date",
           };


### PR DESCRIPTION
Case:
- Set a process variable with `${now()}` in Camunda
- Use it in a carrot-rcc robot (this happens even if you just read it and don't write a new work item)
- After robot runs, it prints `Error: Cannot modify variables for execution: Cannot convert value '2022-02-07T11:47:40.934Z+0200' of type 'Date' to java type java.util.Date"`

The variable is already a valid date string, but carrot-rcc adds a timezone offset without removing the `Z` at the end first. It seemed to me that the string manipulation doesn't actually do anything so I just removed it, and this fixed my issue, but I'm not sure if this is the right solution in the general case. Maybe there are sometimes local times that would need the timezone added.