### PR TITLE
Allow types of Camunda variables to change

### DIFF
--- a/carrot_rcc.ts
+++ b/carrot_rcc.ts
@@ -444,10 +444,10 @@ const save = async (
 
   if (patch.modifications) {
     for (const name of Object.keys(current)) {
-      if (await isEqual(old[name], current[name])) {
+      if (isEqual(old[name], current[name])) {
         continue;
       }
-      switch (await inferType(old[name], current[name])) {
+      switch (inferType(current[name])) {
         case "Boolean":
           patch.modifications[name] = {
             value: !!current[name],

--- a/carrot_rcc_lib.test.ts
+++ b/carrot_rcc_lib.test.ts
@@ -176,70 +176,66 @@ describe("offsetToString", () => {
 describe("isEqual", () => {
   it("should return false when values are not equal", () => {
     expect.assertions(1);
-    return isEqual({ type: "string", value: "foo", valueInfo: {} }, "bar").then(
-      (data) => expect(data).toBe(false)
-    );
+    return expect(
+      isEqual({ type: "string", value: "foo", valueInfo: {} }, "bar")
+    ).toBe(false);
   });
   it("should return true values are equal", () => {
     expect.assertions(1);
-    return isEqual({ type: "string", value: "foo", valueInfo: {} }, "foo").then(
-      (data) => expect(data).toBe(true)
-    );
+    return expect(
+      isEqual({ type: "string", value: "foo", valueInfo: {} }, "foo")
+    ).toBe(true);
   });
   it("should return false for new values", () => {
     expect.assertions(1);
-    return isEqual(undefined, undefined).then((data) =>
-      expect(data).toBe(false)
-    );
+    return expect(isEqual(undefined, undefined)).toBe(false);
   });
   it("should return false for files", () => {
     expect.assertions(1);
-    return isEqual({ type: "file", value: null, valueInfo: {} }, null).then(
-      (data) => expect(data).toBe(false)
-    );
+    return expect(
+      isEqual({ type: "file", value: null, valueInfo: {} }, null)
+    ).toBe(false);
   });
   it("should return false when dates are not equal", () => {
     expect.assertions(1);
     const [a, b] = [new Date(), new Date("2020-01-01")];
-    return isEqual({ type: "date", value: a, valueInfo: {} }, b).then((data) =>
-      expect(data).toBe(false)
+    return expect(isEqual({ type: "date", value: a, valueInfo: {} }, b)).toBe(
+      false
     );
   });
   it("should return true when dates are equal", () => {
     expect.assertions(1);
     const a = new Date();
-    return isEqual({ type: "date", value: a, valueInfo: {} }, a).then((data) =>
-      expect(data).toBe(true)
+    return expect(isEqual({ type: "date", value: a, valueInfo: {} }, a)).toBe(
+      true
     );
   });
   it("should return true when date does not match ISO string", () => {
     expect.assertions(1);
     const [a, b] = [new Date(), new Date("2020-01-01")];
-    return isEqual(
-      { type: "date", value: a, valueInfo: {} },
-      b.toISOString()
-    ).then((data) => expect(data).toBe(false));
+    return expect(
+      isEqual({ type: "date", value: a, valueInfo: {} }, b.toISOString())
+    ).toBe(false);
   });
   it("should return true when date matches ISO string", () => {
     expect.assertions(1);
     const a = new Date();
-    return isEqual(
-      { type: "date", value: a, valueInfo: {} },
-      a.toISOString()
-    ).then((data) => expect(data).toBe(true));
+    return expect(
+      isEqual({ type: "date", value: a, valueInfo: {} }, a.toISOString())
+    ).toBe(true);
   });
   it('should return false when date does not match "YYYY-MM-DD" string', () => {
     expect.assertions(1);
     const [a, b] = [new Date("2020-01-01"), "2020-01-02"];
-    return isEqual({ type: "date", value: a, valueInfo: {} }, b).then((data) =>
-      expect(data).toBe(false)
+    return expect(isEqual({ type: "date", value: a, valueInfo: {} }, b)).toBe(
+      false
     );
   });
   it('should return true when date matches "YYYY-MM-DD" string', () => {
     expect.assertions(1);
     const [a, b] = [new Date("2020-01-01"), "2020-01-01"];
-    return isEqual({ type: "date", value: a, valueInfo: {} }, b).then((data) =>
-      expect(data).toBe(true)
+    return expect(isEqual({ type: "date", value: a, valueInfo: {} }, b)).toBe(
+      true
     );
   });
 });
@@ -247,72 +243,51 @@ describe("isEqual", () => {
 describe("inferType", () => {
   it('should infer "object" as JSON', () => {
     expect.assertions(1);
-    return inferType({ type: "object", value: {}, valueInfo: {} }, {}).then(
-      (data) => expect(data).toBe("Json")
-    );
-  });
-  it("should default to existing variable type when available", () => {
-    expect.assertions(1);
-    return inferType({ type: "file", value: {}, valueInfo: {} }, {}).then(
-      (data) => expect(data).toBe("File")
+    return expect(inferType({ type: "object", value: {}, valueInfo: {} })).toBe(
+      "Json"
     );
   });
   it('should infer true values as "Boolean"', () => {
     expect.assertions(1);
-    return inferType(undefined, true).then((data) =>
-      expect(data).toBe("Boolean")
-    );
+    return expect(inferType(true)).toBe("Boolean");
   });
   it('should infer false values as "Boolean"', () => {
     expect.assertions(1);
-    return inferType(undefined, false).then((data) =>
-      expect(data).toBe("Boolean")
-    );
+    return expect(inferType(false)).toBe("Boolean");
   });
   it('should infer date strings as "Date"', () => {
     expect.assertions(1);
-    return inferType(undefined, "2020-01-01").then((data) =>
-      expect(data).toBe("Date")
-    );
+    return expect(inferType("2020-01-01")).toBe("Date");
   });
   it('should infer ISO date strings as "Date"', () => {
     expect.assertions(1);
-    return inferType(undefined, "2022-02-07T19:16:08.644Z").then((data) =>
-      expect(data).toBe("Date")
-    );
+    return expect(inferType("2022-02-07T19:16:08.644Z")).toBe("Date");
   });
   it('should infer other strings as "String"', () => {
     expect.assertions(1);
-    return inferType(
-      undefined,
-      "This is not a date 2022-02-07T19:16:08.644Z"
-    ).then((data) => expect(data).toBe("String"));
+    return expect(
+      inferType("This is not a date 2022-02-07T19:16:08.644Z")
+    ).toBe("String");
   });
   it('should infer date values as "Date"', () => {
     expect.assertions(1);
-    return inferType(undefined, new Date()).then((data) =>
-      expect(data).toBe("Date")
-    );
+    return expect(inferType(new Date())).toBe("Date");
   });
   it('should infer integer numbers values as "Integer"', () => {
     expect.assertions(1);
-    return inferType(undefined, 1).then((data) => expect(data).toBe("Integer"));
+    return expect(inferType(1)).toBe("Integer");
   });
   it('should infer long numbers values as "Long"', () => {
     expect.assertions(1);
-    return inferType(undefined, Math.pow(2, 31)).then((data) =>
-      expect(data).toBe("Long")
-    );
+    return expect(inferType(Math.pow(2, 31))).toBe("Long");
   });
   it('should infer other numbers values as "Double"', () => {
     expect.assertions(1);
-    return inferType(undefined, 1.1).then((data) =>
-      expect(data).toBe("Double")
-    );
+    return expect(inferType(1.1)).toBe("Double");
   });
   it("should infer other values as JSON", () => {
     expect.assertions(1);
-    return inferType(undefined, null).then((data) => expect(data).toBe("Json"));
+    return expect(inferType(null)).toBe("Json");
   });
 });
 

--- a/carrot_rcc_lib.ts
+++ b/carrot_rcc_lib.ts
@@ -43,14 +43,16 @@ export const TZ: string = ((): string => {
   return offsetToString(offset);
 })();
 
-export const isEqual = async (
-  old: TypedValue | undefined,
-  current: any
-): Promise<boolean> => {
+export const isEqual = (old: TypedValue | undefined, current: any): boolean => {
   if (old === undefined) {
     return false;
   }
-  switch (await inferType(old, current)) {
+  const oldType = inferType(old);
+  const currType = inferType(current);
+  if (oldType !== currType) {
+    return false;
+  }
+  switch (currType) {
     case "File":
       return false;
     case "Date":
@@ -60,16 +62,8 @@ export const isEqual = async (
   }
 };
 
-export const inferType = async (
-  old: TypedValue | undefined,
-  current: any
-): Promise<string> => {
-  if (old?.type === "object") {
-    // We can only save deserialized objects back as JSON
-    return "Json";
-  } else if (old?.type) {
-    return old.type[0].toUpperCase() + old.type.substr(1);
-  } else if (isBoolean(current)) {
+export const inferType = (current: any): string => {
+  if (isBoolean(current)) {
     return "Boolean";
   } else if (isDate(current)) {
     return "Date";

--- a/carrot_rcc_lib.ts
+++ b/carrot_rcc_lib.ts
@@ -47,9 +47,8 @@ export const isEqual = (old: TypedValue | undefined, current: any): boolean => {
   if (old === undefined) {
     return false;
   }
-  const oldType = inferType(old);
   const currType = inferType(current);
-  if (oldType !== currType) {
+  if (old.type.toUpperCase() !== currType.toUpperCase()) {
     return false;
   }
   switch (currType) {


### PR DESCRIPTION
Use case: a robot is called repeatedly to check if an operation in an external system has been completed. If not, certain variables are null. Once the operation is complete, these variables are populated with information that only exists at the end of the process (timestamp of when the operation finished, specifically). Setting the variable to null gives it a type of Json, but we want it to turn into a Date at the end when the information is available. Currently it becomes a Json string instead, because carrot-rcc does not allow the type to change.

Note: Another thing I tried was to have the robot not set the variable at all until done. However, because carrot-rcc sets variables in local scope, we need an output mapping in the BPMN process to bring the variable to process scope. Doing this with `${execution.getVariableTyped("finishedTime")}` causes a variable of type Null to be created, which has the same problem but worse - carrot-rcc tries to set a variable with type Null and value "datetime string" which causes a fatal conversion error.